### PR TITLE
Tagger fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 	- const float& vbf_2_cvsb
 - Fixed working points for all taggers, per year
 - Charm tagging features now categorical rather than float
+- `hh_kinfit_m` now set to zero rather than NaN when invalid
 - `FeatComp::process`, `EvtProc::process`, `EvtProc::process_as_vec`, and `EvtProc::process_to_vec` now only take a single set of CSV values, rather than CSV and deep*. Pass the CSV values you wish to use. 
 - `FeatComp::FeatComp` and `EvtProc::EvtProc` `_use_deep_csv` arguments renamed to `_use_deep_bjet_wps`
 - `EvtProc::process`, `EvtProc::process_as_vec`, and `EvtProc::process_to_vec` now take the following extra arguments:

--- a/processing/interface/feat_comp.hh
+++ b/processing/interface/feat_comp.hh
@@ -28,7 +28,7 @@ private:
 	// Variables
     bool _all, _use_deep_bjet_wps;
     std::vector<std::string> _requested;
-	std::map<int,std::vector<float>> _deep_wps{{0, {0,0.5803,0.8838,0.9693}},   // Not provided for 2016, copied 2017
+	std::map<int,std::vector<float>> _bjet_wps{{0, {0,0.5803,0.8838,0.9693}},   // Not provided for 2016, copied 2017
 											   {1, {0,0.5803,0.8838,0.9693}},
 											   {2, {0,0.5803,0.8838,0.9693}}};  // Not provided for 2018, copied 2017
 	std::map<int,std::vector<float>> _deep_bjet_wps{{0, {0,0.0614,0.3093,0.7221}},

--- a/processing/src/evt_proc.cc
+++ b/processing/src/evt_proc.cc
@@ -236,8 +236,7 @@ std::vector<std::string> EvtProc::get_feats() {
 
     std::map<std::string, float> feats = EvtProc::process(LorentzVector(), LorentzVector(), LorentzVector(), LorentzVector(), LorentzVector(), LorentzVector(),
                                                           LorentzVector(), LorentzVector(), 0, 0, 0, false, 0, 0, Channel(tauTau),
-                                                          Year(y16), 0, Spin(nonres), 0, 2, true, true, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                                          0, 0, 0, 0, 0, 0, 0, 0);
+                                                          Year(y16), 0, Spin(nonres), 0, 2, true, true, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
     std::vector<std::string> names;
     if (_all) {
         for (auto const& f : feats) names.push_back(f.first);

--- a/processing/src/evt_proc.cc
+++ b/processing/src/evt_proc.cc
@@ -236,7 +236,8 @@ std::vector<std::string> EvtProc::get_feats() {
 
     std::map<std::string, float> feats = EvtProc::process(LorentzVector(), LorentzVector(), LorentzVector(), LorentzVector(), LorentzVector(), LorentzVector(),
                                                           LorentzVector(), LorentzVector(), 0, 0, 0, false, 0, 0, Channel(tauTau),
-                                                          Year(y16), 0, Spin(nonres), 0, 2, true, true, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+                                                          Year(y16), 0, Spin(nonres), 0, 2, true, true, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                          0, 0, 0, 0, 0, 0, 0, 0);
     std::vector<std::string> names;
     if (_all) {
         for (auto const& f : feats) names.push_back(f.first);

--- a/processing/src/feat_comp.cc
+++ b/processing/src/feat_comp.cc
@@ -56,12 +56,12 @@ std::map<std::string, float> FeatComp::process(const LorentzVector& b_1,
     if (FeatComp::_feat_check("n_vbf"))      feats["n_vbf"]      = n_vbf;
     if (FeatComp::_feat_check("b_1_cvsl"))    feats["b_1_cvsl"]   = FeatComp::_get_cvsb_flag(year, b_1_cvsl);
     if (FeatComp::_feat_check("b_2_cvsl"))    feats["b_2_cvsl"]   = FeatComp::_get_cvsb_flag(year, b_2_cvsl);
-    if (FeatComp::_feat_check("vbf_1_cvsl"))  feats["vbf_1_cvsl"] = use_vbf ? FeatComp::_get_cvsb_flag(year, vbf_1_cvsl) : std::nanf("1");
-    if (FeatComp::_feat_check("vbf_2_cvsl"))  feats["vbf_2_cvsl"] = use_vbf ? FeatComp::_get_cvsb_flag(year, vbf_2_cvsl) : std::nanf("1");
+    if (FeatComp::_feat_check("vbf_1_cvsl"))  feats["vbf_1_cvsl"] = use_vbf ? FeatComp::_get_cvsb_flag(year, vbf_1_cvsl) : 4;
+    if (FeatComp::_feat_check("vbf_2_cvsl"))  feats["vbf_2_cvsl"] = use_vbf ? FeatComp::_get_cvsb_flag(year, vbf_2_cvsl) : 4;
     if (FeatComp::_feat_check("b_1_cvsb"))    feats["b_1_cvsb"]   = FeatComp::_get_cvsb_flag(year, b_1_cvsb);
     if (FeatComp::_feat_check("b_2_cvsb"))    feats["b_2_cvsb"]   = FeatComp::_get_cvsb_flag(year, b_2_cvsb);
-    if (FeatComp::_feat_check("vbf_1_cvsb"))  feats["vbf_1_cvsb"] = use_vbf ? FeatComp::_get_cvsb_flag(year, vbf_1_cvsb) : std::nanf("1");
-    if (FeatComp::_feat_check("vbf_2_cvsb"))  feats["vbf_2_cvsb"] = use_vbf ? FeatComp::_get_cvsb_flag(year, vbf_2_cvsb) : std::nanf("1");
+    if (FeatComp::_feat_check("vbf_1_cvsb"))  feats["vbf_1_cvsb"] = use_vbf ? FeatComp::_get_cvsb_flag(year, vbf_1_cvsb) : 4;
+    if (FeatComp::_feat_check("vbf_2_cvsb"))  feats["vbf_2_cvsb"] = use_vbf ? FeatComp::_get_cvsb_flag(year, vbf_2_cvsb) : 4;
     FeatComp::_add_btag_flags(year, b_1_csv, b_2_csv, feats);
 
     // Delta phi
@@ -128,7 +128,7 @@ std::map<std::string, float> FeatComp::process(const LorentzVector& b_1,
     if (FeatComp::_feat_check("sv_mass"))       feats["sv_mass"]       = svfit_conv ? svfit.M() : std::nanf("1");
     if (FeatComp::_feat_check("h_tt_vis_mass")) feats["h_tt_vis_mass"] = h_tt_vis.M();
     if (FeatComp::_feat_check("h_bb_mass"))     feats["h_bb_mass"]     = h_bb.M();
-    if (FeatComp::_feat_check("hh_kinfit_m"))   feats["hh_kinfit_m"]   = hh_kinfit_conv ? hh_kinfit_m : std::nanf("1");
+    if (FeatComp::_feat_check("hh_kinfit_m"))   feats["hh_kinfit_m"]   = hh_kinfit_conv ? hh_kinfit_m : 0;
     if (FeatComp::_feat_check("sv_mt"))         feats["sv_mt"]         = svfit_conv ? FeatComp::calc_mt(svfit, met) : std::nanf("1");
     if (FeatComp::_feat_check("h_tt_met_mt"))   feats["h_tt_met_mt"]   = FeatComp::calc_mt(h_tt_met, met);
     if (FeatComp::_feat_check("l_1_mt"))        feats["l_1_mt"]        = FeatComp::calc_mt(l_1, met);

--- a/processing/src/feat_comp.cc
+++ b/processing/src/feat_comp.cc
@@ -54,14 +54,14 @@ std::map<std::string, float> FeatComp::process(const LorentzVector& b_1,
     if (FeatComp::_feat_check("year"))       feats["year"]       = year;
     if (FeatComp::_feat_check("svfit_conv")) feats["svfit_conv"] = svfit_conv;
     if (FeatComp::_feat_check("n_vbf"))      feats["n_vbf"]      = n_vbf;
-    if (EvtProc::_feat_check("b_1_cvsl"))    feats["b_1_cvsl"]   = FeatComp::_get_cvsb_flag(year, b_1_cvsl);
-    if (EvtProc::_feat_check("b_2_cvsl"))    feats["b_2_cvsl"]   = FeatComp::_get_cvsb_flag(year, b_2_cvsl);
-    if (EvtProc::_feat_check("vbf_1_cvsl"))  feats["vbf_1_cvsl"] = use_vbf ? FeatComp::_get_cvsb_flag(year, vbf_1_cvsl) : std::nanf("1");
-    if (EvtProc::_feat_check("vbf_2_cvsl"))  feats["vbf_2_cvsl"] = use_vbf ? FeatComp::_get_cvsb_flag(year, vbf_2_cvsl) : std::nanf("1");
-    if (EvtProc::_feat_check("b_1_cvsb"))    feats["b_1_cvsb"]   = FeatComp::_get_cvsb_flag(year, b_1_cvsb);
-    if (EvtProc::_feat_check("b_2_cvsb"))    feats["b_2_cvsb"]   = FeatComp::_get_cvsb_flag(year, b_2_cvsb);
-    if (EvtProc::_feat_check("vbf_1_cvsb"))  feats["vbf_1_cvsb"] = use_vbf ? FeatComp::_get_cvsb_flag(year, vbf_1_cvsb) : std::nanf("1");
-    if (EvtProc::_feat_check("vbf_2_cvsb"))  feats["vbf_2_cvsb"] = use_vbf ? FeatComp::_get_cvsb_flag(year, vbf_2_cvsb) : std::nanf("1");
+    if (FeatComp::_feat_check("b_1_cvsl"))    feats["b_1_cvsl"]   = FeatComp::_get_cvsb_flag(year, b_1_cvsl);
+    if (FeatComp::_feat_check("b_2_cvsl"))    feats["b_2_cvsl"]   = FeatComp::_get_cvsb_flag(year, b_2_cvsl);
+    if (FeatComp::_feat_check("vbf_1_cvsl"))  feats["vbf_1_cvsl"] = use_vbf ? FeatComp::_get_cvsb_flag(year, vbf_1_cvsl) : std::nanf("1");
+    if (FeatComp::_feat_check("vbf_2_cvsl"))  feats["vbf_2_cvsl"] = use_vbf ? FeatComp::_get_cvsb_flag(year, vbf_2_cvsl) : std::nanf("1");
+    if (FeatComp::_feat_check("b_1_cvsb"))    feats["b_1_cvsb"]   = FeatComp::_get_cvsb_flag(year, b_1_cvsb);
+    if (FeatComp::_feat_check("b_2_cvsb"))    feats["b_2_cvsb"]   = FeatComp::_get_cvsb_flag(year, b_2_cvsb);
+    if (FeatComp::_feat_check("vbf_1_cvsb"))  feats["vbf_1_cvsb"] = use_vbf ? FeatComp::_get_cvsb_flag(year, vbf_1_cvsb) : std::nanf("1");
+    if (FeatComp::_feat_check("vbf_2_cvsb"))  feats["vbf_2_cvsb"] = use_vbf ? FeatComp::_get_cvsb_flag(year, vbf_2_cvsb) : std::nanf("1");
     FeatComp::_add_btag_flags(year, b_1_csv, b_2_csv, feats);
 
     // Delta phi

--- a/processing/test/feat_comp_test.cc
+++ b/processing/test/feat_comp_test.cc
@@ -32,13 +32,16 @@ int main(int argc, char *argv[]) {
     float hh_kinfit_mass = energy(rng);
     bool is_boosted = csv(rng) > 1.;
     float csv_1(csv(rng)), csv_2(csv(rng));
+    float b_1_cvsl(csv(rng)), b_2_cvsl(csv(rng)), vbf_1_cvsl(csv(rng)), vbf_2_cvsl(csv(rng));
+    float b_1_cvsb(csv(rng)), b_2_cvsb(csv(rng)), vbf_1_cvsb(csv(rng)), vbf_2_cvsb(csv(rng));
     Channel channel = tauTau;
     Year year = y16;
     std::cout << "Generated\n";
 
     std::cout << "Processing event... ";
     std::map<std::string, float> feats = feat_comp.process(b_1, b_2, l_1, l_2, met, sv, vbf_1, vbf_2, hh_kinfit_mass, is_boosted,
-                                                           csv_1, csv_2, channel, year, 0, true, true);
+                                                           csv_1, csv_2, channel, year, 0, true, true, b_1_cvsl, b_2_cvsl, vbf_1_cvsl, vbf_2_cvsl,
+                                                           b_1_cvsb, b_2_cvsb, vbf_1_cvsb, vbf_2_cvsb);
     std::cout << "Processed\n";
 
     for (auto const& f : feats) std::cout << f.first << ":" << f.second << "\n";


### PR DESCRIPTION
- `FeatComp::process` no takes the following extra arguments:
	- const float& b_1_cvsl,
	- const float& b_2_cvsl,
	- const float& vbf_1_cvsl,
	- const float& vbf_2_cvsl,
	- const float& b_1_cvsb,
	- const float& b_2_cvsb,
	- const float& vbf_1_cvsb,
	- const float& vbf_2_cvsb
- Fixed working points for all taggers, per year
- Charm tagging features now categorical rather than float